### PR TITLE
Use pragma once

### DIFF
--- a/list.h
+++ b/list.h
@@ -1,5 +1,4 @@
-#ifndef LIST_H
-#define LIST_H
+#pragma once
 
 #define list_cat2(a,b) a##b
 #define list_cat(a,b) list_cat2(a,b)
@@ -16,5 +15,3 @@
     l[list_lenref(l)-1] = x;\
 } while (0)
 #define list_free(l) free(l?(void*)l-sizeof(size_t):NULL)
-
-#endif


### PR DESCRIPTION
The "once" pragma should be supported everywhere that the ## pre-processor statement is (see https://en.wikipedia.org/wiki/Pragma_once for the list of supported compilers). 

Apart from less code in the header file, it also solves naming collisions. LIST_H may be a bit generic and inviting a collision from elsewhere in a large project.
